### PR TITLE
Change csv output

### DIFF
--- a/src/PathLengthCheckerGUI/MainWindow.xaml.cs
+++ b/src/PathLengthCheckerGUI/MainWindow.xaml.cs
@@ -274,10 +274,10 @@ namespace PathLengthCheckerGUI
 			var text = new StringBuilder();
 			foreach (var path in Paths)
 			{
-				var item = includeLength ? $"{path.Length},{path.Path}" : path.Path;
-				text.Append(item + ",");
+				var item = includeLength ? $"{path.Length};\"{path.Path}\"" : path.Path;
+				text.Append(item + (char)13 + (char)10);
 			}
-			return text.ToString().TrimEnd(',');
+			return text.ToString();
 		}
 
 		/// <summary>


### PR DESCRIPTION
add TextEncapsulator " for path // making sure that column delimiter in path does not mess up columns
change column delimiter to ; // tribute to MS-Excel as well as avoiding conflicts with comma in path, if no TextEncapsulator is used
change record delimiter to CRLF // standard csv record delimiter in MS-Windows